### PR TITLE
Add the option Emummc SYSTEM in the correct place

### DIFF
--- a/scripts/Dump_saves.te
+++ b/scripts/Dump_saves.te
@@ -10,7 +10,9 @@ partNames.foreach("x"){
 }
 
 if (emu()){
-	menuOptions.add("Emummc " + x)
+	partNames.foreach("x"){
+		menuOptions.add("Emummc " + x)
+	}
 }
 
 res = menu(menuOptions, 0)


### PR DESCRIPTION
the previous version of this script always show the same 3 options:

0 Exit
1 Sysmmc SYSTEM
2 Sysmmc USER
3 Emummc USER

the code says
```
if (res % 2) {
	mountStr = "SYSTEM"
}.else() {
	mountStr = "USER"
}

if (res > 2) {
	mount = mountemu
}.else() {
	mount = mountsys
}
```
Then, when you select "Emummc USER" to saves yours games savedata, the system select "Emummc SYSTEM".

Thanks for TegraExplorer!